### PR TITLE
feat: implement paginated user list

### DIFF
--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { getUsers, getUserById, createUser, updateUser, deleteUser, registerUser, loginUser } from './users.service';
+import { getAllUsers, getUsers, getUserById, createUser, updateUser, deleteUser, registerUser, loginUser } from './users.service';
 
 const registerSchema = t.Object({
   name: t.String({ minLength: 1 }),
@@ -12,9 +12,18 @@ const loginSchema = t.Object({
   password: t.String({ minLength: 1 }),
 });
 
+const paginationQuery = t.Object({
+  page: t.Number({ minimum: 1, default: 1 }),
+  size: t.Number({ minimum: 1, maximum: 100, default: 10 }),
+});
+
 export const usersRouter = new Elysia({ prefix: '/api/users' })
-  .get('/', async () => {
-    return getUsers();
+  .get('/', async ({ query }) => {
+    const page = query.page ?? 1;
+    const size = query.size ?? 10;
+    return getUsers(page, size);
+  }, {
+    query: paginationQuery,
   })
   .get('/:id', async ({ params }) => {
     const id = Number(params.id);

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,11 +1,42 @@
 import { db } from '../../db';
 import { users, sessions } from './users.schema';
-import { eq } from 'drizzle-orm';
+import { eq, count } from 'drizzle-orm';
 import type { User, NewUser } from './users.schema';
 import argon2 from 'argon2';
 
-export async function getUsers(): Promise<User[]> {
+export async function getAllUsers(): Promise<User[]> {
   return db.select().from(users);
+}
+
+export async function getUsers(page: number, size: number) {
+  const offset = (page - 1) * size;
+  
+  const usersData = await db.select({
+    id: users.id,
+    name: users.name,
+    email: users.email,
+    createdAt: users.createdAt,
+  }).from(users).limit(size).offset(offset);
+  
+  const totalRecordsResult = await db.select({ count: count() }).from(users);
+  const totalRecords = totalRecordsResult[0]!.count;
+  
+  const totalPages = Math.ceil(totalRecords / size);
+  
+  const nextUrl = page < totalPages ? `/api/users?page=${page + 1}&size=${size}` : null;
+  const prevUrl = page > 1 ? `/api/users?page=${page - 1}&size=${size}` : null;
+  
+  return {
+    data: usersData,
+    meta: {
+      current_page: page,
+      page_size: size,
+      total_records: totalRecords,
+      total_pages: totalPages,
+      next_url: nextUrl,
+      prev_url: prevUrl,
+    },
+  };
 }
 
 export async function getUserById(id: number): Promise<User[]> {


### PR DESCRIPTION
## Summary
- Add getUsers function with pagination in users.service.ts
- Add GET /api/users route with query param validation

## Testing
- ✅ GET /api/users returns 200 with defaults (page=1, size=10)
- ✅ GET /api/users?page=2&size=10 returns correct slice
- ✅ Meta values correctly calculated
- ✅ next_url is null on last page, prev_url is null on first page
- ✅ Response never includes password field
- ✅ Invalid params return 422