### PR TITLE
feat: implement update current user password

### DIFF
--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { getAllUsers, getUsers, getUserById, createUser, updateUser, deleteUser, registerUser, loginUser, getCurrentUser, updateCurrentUser } from './users.service';
+import { getAllUsers, getUsers, getUserById, createUser, updateUser, deleteUser, registerUser, loginUser, getCurrentUser, updateCurrentUser, updatePassword } from './users.service';
 
 const registerSchema = t.Object({
   name: t.String({ minLength: 1 }),
@@ -15,6 +15,11 @@ const loginSchema = t.Object({
 const updateProfileSchema = t.Object({
   name: t.String({ minLength: 1 }),
   email: t.String({ format: 'email' }),
+});
+
+const updatePasswordSchema = t.Object({
+  oldPassword: t.String({ minLength: 1 }),
+  newPassword: t.String({ minLength: 8 }),
 });
 
 const paginationQuery = t.Object({
@@ -85,6 +90,38 @@ export const usersRouter = new Elysia({ prefix: '/api/users' })
     }
   }, {
     body: updateProfileSchema,
+  })
+  .put('/me/password', async ({ headers, body, set }) => {
+    const authHeader = headers['authorization'];
+    
+    if (!authHeader) {
+      set.status = 401;
+      return { error: 'Unauthorized' };
+    }
+    
+    const parts = authHeader.split(' ');
+    if (parts.length !== 2 || parts[0] !== 'Bearer') {
+      set.status = 401;
+      return { error: 'Unauthorized' };
+    }
+    
+    const token = parts[1]!;
+    const { oldPassword, newPassword } = body as { oldPassword: string; newPassword: string };
+    
+    try {
+      await updatePassword(token, oldPassword, newPassword);
+      return { data: 'OK' };
+    } catch (error) {
+      const errorMessage = (error as Error).message;
+      if (errorMessage === 'Unauthorized') {
+        set.status = 401;
+        return { error: 'Unauthorized' };
+      }
+      set.status = 400;
+      return { error: errorMessage };
+    }
+  }, {
+    body: updatePasswordSchema,
   })
   .get('/:id', async ({ params }) => {
     const id = Number(params.id);

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -128,3 +128,31 @@ export async function updateCurrentUser(token: string, name: string, email: stri
   
   return 'OK';
 }
+
+export async function updatePassword(token: string, oldPassword: string, newPassword: string) {
+  const session = await db.select().from(sessions).where(eq(sessions.token, token));
+  
+  if (session.length === 0) {
+    throw new Error('Unauthorized');
+  }
+  
+  const userId = session[0]!.userId;
+  
+  const userRecord = await db.select().from(users).where(eq(users.id, userId));
+  
+  if (userRecord.length === 0) {
+    throw new Error('Unauthorized');
+  }
+  
+  const user = userRecord[0]!;
+  const isValidPassword = await argon2.verify(user.password, oldPassword);
+  
+  if (!isValidPassword) {
+    throw new Error('The old password is not match');
+  }
+  
+  const hashedNewPassword = await argon2.hash(newPassword);
+  await db.update(users).set({ password: hashedNewPassword }).where(eq(users.id, userId));
+  
+  return 'OK';
+}


### PR DESCRIPTION
## Summary
- Add updatePassword function in users.service.ts
- Add PUT /api/users/me/password route with Authorization header and body validation

## Testing
- ✅ PUT /api/users/me/password with valid token and correct oldPassword returns 200
- ✅ After update, old password no longer works
- ✅ Without Authorization header returns 401
- ✅ With invalid token returns 401
- ✅ With incorrect oldPassword returns 400
- ✅ With newPassword < 8 characters returns 422
- ✅ With empty oldPassword returns 422
- ✅ Password stored is hashed