### PR TITLE
feat: implement logout current user

### DIFF
--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from 'elysia';
-import { getAllUsers, getUsers, getUserById, createUser, updateUser, deleteUser, registerUser, loginUser, getCurrentUser, updateCurrentUser, updatePassword } from './users.service';
+import { getAllUsers, getUsers, getUserById, createUser, updateUser, deleteUser, registerUser, loginUser, getCurrentUser, updateCurrentUser, updatePassword, logoutUser } from './users.service';
 
 const registerSchema = t.Object({
   name: t.String({ minLength: 1 }),
@@ -149,6 +149,30 @@ export const usersRouter = new Elysia({ prefix: '/api/users' })
     }
   }, {
     body: loginSchema,
+  })
+  .delete('/logout', async ({ headers, set }) => {
+    const authHeader = headers['authorization'];
+    
+    if (!authHeader) {
+      set.status = 401;
+      return { error: 'Unauthorized' };
+    }
+    
+    const parts = authHeader.split(' ');
+    if (parts.length !== 2 || parts[0] !== 'Bearer') {
+      set.status = 401;
+      return { error: 'Unauthorized' };
+    }
+    
+    const token = parts[1]!;
+    
+    try {
+      await logoutUser(token);
+      return { data: 'OK' };
+    } catch (error) {
+      set.status = 401;
+      return { error: 'Unauthorized' };
+    }
   })
   .put('/:id', async ({ params, body }) => {
     const id = Number(params.id);

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -156,3 +156,15 @@ export async function updatePassword(token: string, oldPassword: string, newPass
   
   return 'OK';
 }
+
+export async function logoutUser(token: string) {
+  const session = await db.select().from(sessions).where(eq(sessions.token, token));
+  
+  if (session.length === 0) {
+    throw new Error('Unauthorized');
+  }
+  
+  await db.delete(sessions).where(eq(sessions.token, token));
+  
+  return 'OK';
+}


### PR DESCRIPTION
## Summary
- Add logoutUser function in users.service.ts
- Add DELETE /api/users/logout route with Authorization header validation

## Testing
- ✅ DELETE /api/users/logout with valid token returns 200
- ✅ After logout, token is no longer valid
- ✅ Without Authorization header returns 401
- ✅ With invalid token returns 401
- ✅ Only current token's session is deleted