### PR TITLE
fix: add maxLength validation to all string fields

### DIFF
--- a/src/modules/users/users.validation.ts
+++ b/src/modules/users/users.validation.ts
@@ -1,24 +1,24 @@
 import { t } from "elysia";
 
 export const registerSchema = t.Object({
-  name: t.String({ minLength: 1 }),
-  email: t.String({ format: "email" }),
-  password: t.String({ minLength: 8 }),
+  name: t.String({ minLength: 1, maxLength: 255 }),
+  email: t.String({ format: "email", maxLength: 255 }),
+  password: t.String({ minLength: 8, maxLength: 255 }),
 });
 
 export const loginSchema = t.Object({
-  email: t.String({ format: "email" }),
-  password: t.String({ minLength: 1 }),
+  email: t.String({ format: "email", maxLength: 255 }),
+  password: t.String({ minLength: 1, maxLength: 255 }),
 });
 
 export const updateProfileSchema = t.Object({
-  name: t.String({ minLength: 1 }),
-  email: t.String({ format: "email" }),
+  name: t.String({ minLength: 1, maxLength: 255 }),
+  email: t.String({ format: "email", maxLength: 255 }),
 });
 
 export const updatePasswordSchema = t.Object({
-  oldPassword: t.String({ minLength: 1 }),
-  newPassword: t.String({ minLength: 8 }),
+  oldPassword: t.String({ minLength: 1, maxLength: 255 }),
+  newPassword: t.String({ minLength: 8, maxLength: 255 }),
 });
 
 export const paginationQuery = t.Object({


### PR DESCRIPTION
## Summary
- Add maxLength: 255 to all string fields in users.validation.ts

## Testing
- ✅ POST /api/users with name > 255 chars returns 422
- ✅ POST /api/users with email > 255 chars returns 422
- ✅ POST /api/users with password > 255 chars returns 422
- ✅ POST /api/users/login with email > 255 chars returns 422
- ✅ POST /api/users/login with password > 255 chars returns 422
- ✅ PUT /api/users/me with name > 255 chars returns 422
- ✅ PUT /api/users/me with email > 255 chars returns 422
- ✅ PUT /api/users/me/password with oldPassword > 255 chars returns 422
- ✅ PUT /api/users/me/password with newPassword > 255 chars returns 422
- ✅ All endpoints still work with valid inputs